### PR TITLE
Add `polonius_try!` macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "polonius-the-crab"
-version = "0.2.0"
+version = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "polonius-the-crab"
 authors = [
     "Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>",
 ]
-version = "0.2.0"  # Keep in sync
+version = "0.2.1"  # Keep in sync
 edition = "2021"
 rust-version = "1.56.0"
 


### PR DESCRIPTION
Adds a `polonius_try!` operator to be used inside `polonius{,_loop}!` scopes to perform `?` "unwrapping" on `Result`s.