### PR TITLE
Remove unnecessary type inference nudge in `polonius_loop!`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "polonius-the-crab"
-version = "0.3.0"
+version = "0.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "polonius-the-crab"
 authors = [
     "Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>",
 ]
-version = "0.3.0"  # Keep in sync
+version = "0.3.1"  # Keep in sync
 edition = "2021"
 rust-version = "1.56.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -494,9 +494,6 @@ macro_rules! polonius_loop {(
                     #[allow(clippy::self_assignment)] {
                         $var = $var;
                     }
-                    if false {
-                        $crate::polonius_break_dependent!(loop {});
-                    }
                     let () =
                         if true
                             $body


### PR DESCRIPTION
Such unnecessary "type inference nudge" was triggering the `unreachable_code` lint.

Fixes #9 