### PR TITLE
Soundness test "fix": work around nightly change of `-Zpolonius`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,16 +131,16 @@ where
         // which `cargo check`s this very snippet without this `unsafe`.
         &mut *(input_borrow as *mut _)
     };
-    match branch(tentative_borrow) {
+    let owned_value = match branch(tentative_borrow) {
         | PoloniusResult::Borrowing(dependent) => {
-            PoloniusResult::Borrowing(dependent)
+            return PoloniusResult::Borrowing(dependent);
         },
-        | PoloniusResult::Owned { value, .. } => {
-            PoloniusResult::Owned {
-                value,
-                input_borrow,
-            }
-        },
+        | PoloniusResult::Owned { value, .. } => value,
+    }; // <- `drop(PoloniusResult::Owned { .. })`.
+       // See https://github.com/rust-lang/rust/issues/126520 for more info.
+    PoloniusResult::Owned {
+        value: owned_value,
+        input_borrow,
     }
 }
 


### PR DESCRIPTION
Fixes the "future-proofing CI" failures caused by a "false positive regression" in nightly rustc's semantics of `-Zpolonius`.

This crate tries to justify its usage of `unsafe` by offering a way to disable it when `-Zpolonius` is used, _via_ its Cargo `--feature polonius`.

Indeed, when `-Zpolonius` is being used, there is no need to used any of the API of this crate, which, in fact, includes the very implementation of this crate. So we do precisely that, thereby avoiding the need for any `unsafe`, and thus "proving" that our branch API is sound, _even beyond a `-Zpolonius` context_, since it is proven to be sound there.

However, around June, the semantics of `-Zpolonius` changed a bit in `rustc` (nightly), and this non-`unsafe`-`-Zpolonius`-vetted implementation was actually being rejected by it.

There is, in fact, an issue about this very thing:

  - https://github.com/rust-lang/rust/issues/126520

It is unclear whether the rejection is fully legitimate; in this case, and also in the minimization I wrote on that issue, it is a false positive: in the non-dependent branch, there is nothing _dependent_ being dropped "after" our `return` "starts". Still, it may be difficult for the compiler maintainer(s) working on this areä to properly identify and distinguish this legitimate case from one where the drop could have been problematic (in such cases, the change of `-Zpolonius` semantics was actually a soundness fix!).

We thus decide to just work around this tiny "false positive regression" issue by making sure our "drop" of the remainders of the non-dependent value (which happen to be a silly empty ZST (`Placeholder`)) clearly happen, syntactically, before our re-access to the initially (re)borrowed value occurs, when we "start" our `return`.